### PR TITLE
Fix: Correct audio file references and obsolete scripts

### DIFF
--- a/generatePage.js
+++ b/generatePage.js
@@ -1,3 +1,8 @@
+/*
+NOTE: This script is obsolete and is NOT used to generate the current index.html or script.js.
+The existing index.html and script.js files were manually created and are more advanced.
+This script is kept for historical purposes only.
+*/
 var fs = require('fs');
 var path = require('path');
 var { htmlStart, htmlEnd, jsStart, jsEnd } = require('./pageElements')

--- a/index.html
+++ b/index.html
@@ -59,281 +59,281 @@
             <h3>KDA</h3>
             <input type="checkbox" id="kda_early_drums" name="kda_early_drums" class="early">
             <label for="kda_early_drums">early_drums</label>
-            <audio id="audiokda_early_drums" src="tracks/kda_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audiokda_early_drums" src="tracks/kda_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="kda_early_main" name="kda_early_main" class="early">
             <label for="kda_early_main">early_main</label>
-            <audio id="audiokda_early_main" src="tracks/kda_early_main.ogg" preload="none" loop></audio>
+            <audio id="audiokda_early_main" src="tracks/kda_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="kda_early_secondary" name="kda_early_secondary" class="early">
             <label for="kda_early_secondary">early_secondary</label>
-            <audio id="audiokda_early_secondary" src="tracks/kda_early_secondary.ogg" preload="none" loop></audio>
+            <audio id="audiokda_early_secondary" src="tracks/kda_early_secondary.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="kda_late_drums" name="kda_late_drums" class="late">
             <label for="kda_late_drums">late_drums</label>
-            <audio id="audiokda_late_drums" src="tracks/kda_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audiokda_late_drums" src="tracks/kda_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="kda_late_main" name="kda_late_main" class="late">
             <label for="kda_late_main">late_main</label>
-            <audio id="audiokda_late_main" src="tracks/kda_late_main.ogg" preload="none" loop></audio>
+            <audio id="audiokda_late_main" src="tracks/kda_late_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="kda_late_secondary" name="kda_late_secondary" class="late">
             <label for="kda_late_secondary">late_secondary</label>
-            <audio id="audiokda_late_secondary" src="tracks/kda_late_secondary.ogg" preload="none" loop></audio>
+            <audio id="audiokda_late_secondary" src="tracks/kda_late_secondary.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/punk.png" alt="Punk">
             <h3>Punk</h3>
             <input type="checkbox" id="punk_early_drums" name="punk_early_drums" class="early">
             <label for="punk_early_drums">early_drums</label>
-            <audio id="audiopunk_early_drums" src="tracks/punk_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audiopunk_early_drums" src="tracks/punk_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="punk_early_main" name="punk_early_main" class="early">
             <label for="punk_early_main">early_main</label>
-            <audio id="audiopunk_early_main" src="tracks/punk_early_main.ogg" preload="none" loop></audio>
+            <audio id="audiopunk_early_main" src="tracks/punk_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="punk_late_drums" name="punk_late_drums" class="late">
             <label for="punk_late_drums">late_drums</label>
-            <audio id="audiopunk_late_drums" src="tracks/punk_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audiopunk_late_drums" src="tracks/punk_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="punk_late_main" name="punk_late_main" class="late">
             <label for="punk_late_main">late_main</label>
-            <audio id="audiopunk_late_main" src="tracks/punk_late_main.ogg" preload="none" loop></audio>
+            <audio id="audiopunk_late_main" src="tracks/punk_late_main.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/maestro.png" alt="maestro">
             <h3>Maestro</h3>
             <input type="checkbox" id="maestro_early" name="maestro_early" class="early">
             <label for="maestro_early">early</label>
-            <audio id="audiomaestro_early" src="tracks/maestro_early.ogg" preload="none" loop></audio>
+            <audio id="audiomaestro_early" src="tracks/maestro_early.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="maestro_late" name="maestro_late" class="late">
             <label for="maestro_late">late</label>
-            <audio id="audiomaestro_late" src="tracks/maestro_late.ogg" preload="none" loop></audio>
+            <audio id="audiomaestro_late" src="tracks/maestro_late.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/8bit.png" alt="8bit">
             <h3>8 Bit</h3>
             <input type="checkbox" id="8bit_early_drums" name="8bit_early_drums" class="early">
             <label for="8bit_early_drums">early_drums</label>
-            <audio id="audio8bit_early_drums" src="tracks/8bit_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audio8bit_early_drums" src="tracks/8bit_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="8bit_early_main" name="8bit_early_main" class="early">
             <label for="8bit_early_main">early_main</label>
-            <audio id="audio8bit_early_main" src="tracks/8bit_early_main.ogg" preload="none" loop></audio>
+            <audio id="audio8bit_early_main" src="tracks/8bit_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="8bit_late_drums" name="8bit_late_drums" class="late">
             <label for="8bit_late_drums">late_drums</label>
-            <audio id="audio8bit_late_drums" src="tracks/8bit_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audio8bit_late_drums" src="tracks/8bit_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="8bit_late_main" name="8bit_late_main" class="late">
             <label for="8bit_late_main">late_main</label>
-            <audio id="audio8bit_late_main" src="tracks/8bit_late_main.ogg" preload="none" loop></audio>
+            <audio id="audio8bit_late_main" src="tracks/8bit_late_main.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/country.png" alt="8bit">
             <h3>Country</h3>
             <input type="checkbox" id="country_early_drums" name="country_early_drums" class="early">
             <label for="country_early_drums">early_drums</label>
-            <audio id="audiocountry_early_drums" src="tracks/country_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audiocountry_early_drums" src="tracks/country_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="country_early_main" name="country_early_main" class="early">
             <label for="country_early_main">early_main</label>
-            <audio id="audiocountry_early_main" src="tracks/country_early_main.ogg" preload="none" loop></audio>
+            <audio id="audiocountry_early_main" src="tracks/country_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="country_late_drums" name="country_late_drums" class="late">
             <label for="country_late_drums">late_drums</label>
-            <audio id="audiocountry_late_drums" src="tracks/country_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audiocountry_late_drums" src="tracks/country_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="country_late_main" name="country_late_main" class="late">
             <label for="country_late_main">late_main</label>
-            <audio id="audiocountry_late_main" src="tracks/country_late_main.ogg" preload="none" loop></audio>
+            <audio id="audiocountry_late_main" src="tracks/country_late_main.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/disco.png" alt="disco">
             <h3>Disco</h3>
             <input type="checkbox" id="disco_early_drums" name="disco_early_drums" class="early">
             <label for="disco_early_drums">early_drums</label>
-            <audio id="audiodisco_early_drums" src="tracks/disco_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audiodisco_early_drums" src="tracks/disco_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="disco_early_main" name="disco_early_main" class="early">
             <label for="disco_early_main">early_main</label>
-            <audio id="audiodisco_early_main" src="tracks/disco_early_main.ogg" preload="none" loop></audio>
+            <audio id="audiodisco_early_main" src="tracks/disco_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="disco_late_drums" name="disco_late_drums" class="late">
             <label for="disco_late_drums">late_drums</label>
-            <audio id="audiodisco_late_drums" src="tracks/disco_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audiodisco_late_drums" src="tracks/disco_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="disco_late_main" name="disco_late_main" class="late">
             <label for="disco_late_main">late_main</label>
-            <audio id="audiodisco_late_main" src="tracks/disco_late_main.ogg" preload="none" loop></audio>
+            <audio id="audiodisco_late_main" src="tracks/disco_late_main.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/edm.png" alt="EDM">
             <h3>EDM</h3>
             <input type="checkbox" id="edm_early_drums" name="edm_early_drums" class="early">
             <label for="edm_early_drums">early_drums</label>
-            <audio id="audioedm_early_drums" src="tracks/edm_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audioedm_early_drums" src="tracks/edm_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="edm_early_main" name="edm_early_main" class="early">
             <label for="edm_early_main">early_main</label>
-            <audio id="audioedm_early_main" src="tracks/edm_early_main.ogg" preload="none" loop></audio>
+            <audio id="audioedm_early_main" src="tracks/edm_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="edm_late_drums" name="edm_late_drums" class="late">
             <label for="edm_late_drums">late_drums</label>
-            <audio id="audioedm_late_drums" src="tracks/edm_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audioedm_late_drums" src="tracks/edm_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="edm_late_main" name="edm_late_main" class="late">
             <label for="edm_late_main">late_main</label>
-            <audio id="audioedm_late_main" src="tracks/edm_late_main.ogg" preload="none" loop></audio>
+            <audio id="audioedm_late_main" src="tracks/edm_late_main.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/emo.png" alt="emo">
             <h3>Emo</h3>
             <input type="checkbox" id="emo_early_drums" name="emo_early_drums" class="early">
             <label for="emo_early_drums">early_drums</label>
-            <audio id="audioemo_early_drums" src="tracks/emo_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audioemo_early_drums" src="tracks/emo_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="emo_early_main" name="emo_early_main" class="early">
             <label for="emo_early_main">early_main</label>
-            <audio id="audioemo_early_main" src="tracks/emo_early_main.ogg" preload="none" loop></audio>
+            <audio id="audioemo_early_main" src="tracks/emo_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="emo_late_drums" name="emo_late_drums" class="late">
             <label for="emo_late_drums">late_drums</label>
-            <audio id="audioemo_late_drums" src="tracks/emo_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audioemo_late_drums" src="tracks/emo_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="emo_late_main" name="emo_late_main" class="late">
             <label for="emo_late_main">late_main</label>
-            <audio id="audioemo_late_main" src="tracks/emo_late_main.ogg" preload="none" loop></audio>
+            <audio id="audioemo_late_main" src="tracks/emo_late_main.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/heartsteel.png" alt="heartsteel">
             <h3>Heartsteel</h3>
             <input type="checkbox" id="heartsteel_early_drums" name="heartsteel_early_drums" class="early">
             <label for="heartsteel_early_drums">early_drums</label>
-            <audio id="audioheartsteel_early_drums" src="tracks/heartsteel_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audioheartsteel_early_drums" src="tracks/heartsteel_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="heartsteel_early_main" name="heartsteel_early_main" class="early">
             <label for="heartsteel_early_main">early_main</label>
-            <audio id="audioheartsteel_early_main" src="tracks/heartsteel_early_main.ogg" preload="none" loop></audio>
+            <audio id="audioheartsteel_early_main" src="tracks/heartsteel_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="heartsteel_early_secondary" name="heartsteel_early_secondary" class="early">
             <label for="heartsteel_early_secondary">early_secondary</label>
-            <audio id="audioheartsteel_early_secondary" src="tracks/heartsteel_early_secondary.ogg" preload="none" loop></audio>
+            <audio id="audioheartsteel_early_secondary" src="tracks/heartsteel_early_secondary.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="heartsteel_late_drums" name="heartsteel_late_drums" class="late">
             <label for="heartsteel_late_drums">late_drums</label>
-            <audio id="audioheartsteel_late_drums" src="tracks/illbeats_late.ogg" preload="none" loop></audio>
+            <audio id="audioheartsteel_late_drums" src="tracks/heartsteel_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="heartsteel_late_main" name="heartsteel_late_main" class="late">
             <label for="heartsteel_late_main">late_main</label>
-            <audio id="audioheartsteel_late_main" src="tracks/heartsteel_late_main.ogg" preload="none" loop></audio>
+            <audio id="audioheartsteel_late_main" src="tracks/heartsteel_late_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="heartsteel_late_secondary" name="heartsteel_late_secondary" class="late">
             <label for="heartsteel_late_secondary">late_secondary</label>
-            <audio id="audioheartsteel_late_secondary" src="tracks/heartsteel_late_secondary.ogg" preload="none" loop></audio>
+            <audio id="audioheartsteel_late_secondary" src="tracks/heartsteel_late_secondary.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/hyperpop.png" alt="hyperpop">
             <h3>Hyperpop</h3>
             <input type="checkbox" id="hyperpop_early" name="hyperpop_early" class="early">
             <label for="hyperpop_early">early</label>
-            <audio id="audiohyperpop_early" src="tracks/hyperpop_early.ogg" preload="none" loop></audio>
+            <audio id="audiohyperpop_early" src="tracks/hyperpop_early.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="hyperpop_late" name="hyperpop_late" class="late">
             <label for="hyperpop_late">late</label>
-            <audio id="audiohyperpop_late" src="tracks/hyperpop_late.ogg" preload="none" loop></audio>
+            <audio id="audiohyperpop_late" src="tracks/hyperpop_late.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="hyperpop_late_drums" name="hyperpop_late_drums" class="late">
             <label for="hyperpop_late_drums">late_drums</label>
-            <audio id="audiohyperpop_late_drums" src="tracks/hyperpop_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audiohyperpop_late_drums" src="tracks/hyperpop_late_drums.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/illbeats.png" alt="ILLBEATS">
             <h3>ILLBEATS</h3>
             <input type="checkbox" id="illbeats_early" name="illbeats_early" class="early">
             <label for="illbeats_early">early</label>
-            <audio id="audioillbeats_early" src="tracks/illbeats_early.ogg" preload="none" loop></audio>
+            <audio id="audioillbeats_early" src="tracks/illbeats_early.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="illbeats_late" name="illbeats_late" class="late">
             <label for="illbeats_late">late</label>
-            <audio id="audioillbeats_late" src="tracks/heartsteel_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audioillbeats_late" src="tracks/illbeats_late.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/jazz.png" alt="jazz">
             <h3>Jazz</h3>
             <input type="checkbox" id="jazz_early_main" name="jazz_early_main" class="early">
             <label for="jazz_early_main">early_main</label>
-            <audio id="audiojazz_early_main" src="tracks/jazz_early_main.ogg" preload="none" loop></audio>
+            <audio id="audiojazz_early_main" src="tracks/jazz_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="jazz_late_main" name="jazz_late_main" class="late">
             <label for="jazz_late_main">late_main</label>
-            <audio id="audiojazz_late_main" src="tracks/jazz_late_main.ogg" preload="none" loop></audio>
+            <audio id="audiojazz_late_main" src="tracks/jazz_late_main.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/mixmaster.png" alt="mixmaster">
             <h3>MixMaster</h3>
             <input type="checkbox" id="mixmaster_early" name="mixmaster_early" class="early">
             <label for="mixmaster_early">early</label>
-            <audio id="audiomixmaster_early" src="tracks/mixmaster_early.ogg" preload="none" loop></audio>
+            <audio id="audiomixmaster_early" src="tracks/mixmaster_early.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="mixmaster_late" name="mixmaster_late" class="late">
             <label for="mixmaster_late">late</label>
-            <audio id="audiomixmaster_late" src="tracks/mixmaster_late.ogg" preload="none" loop></audio>
+            <audio id="audiomixmaster_late" src="tracks/mixmaster_late.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/pentakill.png" alt="pentakill">
             <h3>Pentakill</h3>
             <input type="checkbox" id="pentakill_early_drums" name="pentakill_early_drums" class="early">
             <label for="pentakill_early_drums">early_drums</label>
-            <audio id="audiopentakill_early_drums" src="tracks/pentakill_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audiopentakill_early_drums" src="tracks/pentakill_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="pentakill_early_main" name="pentakill_early_main" class="early">
             <label for="pentakill_early_main">early_main</label>
-            <audio id="audiopentakill_early_main" src="tracks/pentakill_early_main.ogg" preload="none" loop></audio>
+            <audio id="audiopentakill_early_main" src="tracks/pentakill_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="pentakill_early_secondary" name="pentakill_early_secondary" class="early">
             <label for="pentakill_early_secondary">early_secondary</label>
-            <audio id="audiopentakill_early_secondary" src="tracks/pentakill_early_secondary.ogg" preload="none" loop></audio>
+            <audio id="audiopentakill_early_secondary" src="tracks/pentakill_early_secondary.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="pentakill_late_drums" name="pentakill_late_drums" class="late">
             <label for="pentakill_late_drums">late_drums</label>
-            <audio id="audiopentakill_late_drums" src="tracks/pentakill_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audiopentakill_late_drums" src="tracks/pentakill_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="pentakill_late_main" name="pentakill_late_main" class="late">
             <label for="pentakill_late_main">late_main</label>
-            <audio id="audiopentakill_late_main" src="tracks/pentakill_late_main.ogg" preload="none" loop></audio>
+            <audio id="audiopentakill_late_main" src="tracks/pentakill_late_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="pentakill_late_secondary" name="pentakill_late_secondary" class="late">
             <label for="pentakill_late_secondary">late_secondary</label>
-            <audio id="audiopentakill_late_secondary" src="tracks/pentakill_late_secondary.ogg" preload="none" loop></audio>
+            <audio id="audiopentakill_late_secondary" src="tracks/pentakill_late_secondary.aac" preload="none" loop></audio>
         </div>
         <div class="trait">
             <img src="icon/truedmg.png" alt="truedamage">
             <h3>True Damage</h3>
             <input type="checkbox" id="truedamage_early_drums" name="truedamage_early_drums" class="early">
             <label for="truedamage_early_drums">early_drums</label>
-            <audio id="audiotruedamage_early_drums" src="tracks/truedamage_early_drums.ogg" preload="none" loop></audio>
+            <audio id="audiotruedamage_early_drums" src="tracks/truedamage_early_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="truedamage_early_main" name="truedamage_early_main" class="early">
             <label for="truedamage_early_main">early_main</label>
-            <audio id="audiotruedamage_early_main" src="tracks/truedamage_early_main.ogg" preload="none" loop></audio>
+            <audio id="audiotruedamage_early_main" src="tracks/truedamage_early_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="truedamage_early_secondary" name="truedamage_early_secondary" class="early">
             <label for="truedamage_early_secondary">early_secondary</label>
-            <audio id="audiotruedamage_early_secondary" src="tracks/truedamage_early_secondary.ogg" preload="none" loop></audio>
+            <audio id="audiotruedamage_early_secondary" src="tracks/truedamage_early_secondary.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="truedamage_late_drums" name="truedamage_late_drums" class="late">
             <label for="truedamage_late_drums">late_drums</label>
-            <audio id="audiotruedamage_late_drums" src="tracks/truedamage_late_drums.ogg" preload="none" loop></audio>
+            <audio id="audiotruedamage_late_drums" src="tracks/truedamage_late_drums.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="truedamage_late_main" name="truedamage_late_main" class="late">
             <label for="truedamage_late_main">late_main</label>
-            <audio id="audiotruedamage_late_main" src="tracks/truedamage_late_main.ogg" preload="none" loop></audio>
+            <audio id="audiotruedamage_late_main" src="tracks/truedamage_late_main.aac" preload="none" loop></audio>
             <br>
             <input type="checkbox" id="truedamage_late_secondary" name="truedamage_late_secondary" class="late">
             <label for="truedamage_late_secondary">late_secondary</label>
-            <audio id="audiotruedamage_late_secondary" src="tracks/truedamage_late_secondary.ogg" preload="none" loop></audio>
+            <audio id="audiotruedamage_late_secondary" src="tracks/truedamage_late_secondary.aac" preload="none" loop></audio>
         </div>
 		</div>
 	</div>
@@ -349,7 +349,6 @@
             <li><button type="button" onclick="applyPreset('preset6')">u/Alunze</button></li>
             <li><button type="button" onclick="applyPreset('preset7')">u/Visible_Tangelo_2731</button></li>
             <li><button type="button" onclick="applyPreset('preset8')">u/weissclimbers</button></li>
-            <li><button type="button" onclick="applyPreset('preset8')">u/Dr_Mr_G</button></li>
             <li><button type="button" onclick="applyPreset('preset9')">u/deleted</button></li>
 	        <li><button type="button" onclick="applyPreset('preset10')">u/liquidrekto 1</button></li>
 	        <li><button type="button" onclick="applyPreset('preset11')">u/liquidrekto 2</button></li>
@@ -365,39 +364,39 @@
         <h3>Other Tracks</h3>
         <input type="checkbox" id="starting_carousel" name="starting_carousel">
         <label for="starting_carousel">Starting Carousel</label>
-        <audio id="audiostarting_carousel" src="tracks/starting_carousel.ogg" preload="none" loop></audio>
+        <audio id="audiostarting_carousel" src="tracks/starting_carousel.aac" preload="none" loop></audio>
         <br>
         <input type="checkbox" id="piano_early" name="piano_early" class="early">
         <label for="piano_early">No Traits Early</label>
-        <audio id="audiopiano_early" src="tracks/piano_early.ogg" preload="none" loop></audio>
+        <audio id="audiopiano_early" src="tracks/piano_early.aac" preload="none" loop></audio>
         <br>
         <input type="checkbox" id="piano_late" name="piano_late" class="late">
         <label for="piano_late">No Traits Late</label>
-        <audio id="audiopiano_late" src="tracks/piano_late.ogg" preload="none" loop></audio>
+        <audio id="audiopiano_late" src="tracks/piano_late.aac" preload="none" loop></audio>
         <br>
         <input type="checkbox" id="death1" name="death1">
         <label for="death1">Death 1</label>
-        <audio id="audiodeath1" src="tracks/death1.ogg" preload="none" loop></audio>
+        <audio id="audiodeath1" src="tracks/death1.aac" preload="none" loop></audio>
         <br>
         <input type="checkbox" id="death2" name="death2">
         <label for="death2">Death 2</label>
-        <audio id="audiodeath2" src="tracks/death2.ogg" preload="none" loop></audio>
+        <audio id="audiodeath2" src="tracks/death2.aac" preload="none" loop></audio>
         <br>
         <input type="checkbox" id="death3" name="death3">
         <label for="death3">Death 3</label>
-        <audio id="audiodeath3" src="tracks/death3.ogg" preload="none" loop></audio>
+        <audio id="audiodeath3" src="tracks/death3.aac" preload="none" loop></audio>
         <br>
         <input type="checkbox" id="death4" name="death4">
         <label for="death4">Death 4</label>
-        <audio id="audiodeath4" src="tracks/death4.ogg" preload="none" loop></audio>
+        <audio id="audiodeath4" src="tracks/death4.aac" preload="none" loop></audio>
         <br>
         <input type="checkbox" id="death5" name="death5">
         <label for="death5">Death 5</label>
-        <audio id="audiodeath5" src="tracks/death5.ogg" preload="none" loop></audio>
+        <audio id="audiodeath5" src="tracks/death5.aac" preload="none" loop></audio>
         <br>
         <input type="checkbox" id="death6" name="death6">
         <label for="death6">Death 6</label>
-        <audio id="audiodeath6" src="tracks/death6.ogg" preload="none" loop></audio>
+        <audio id="audiodeath6" src="tracks/death6.aac" preload="none" loop></audio>
     </div>
     <script src="script.js"></script>
     <hr>

--- a/pageElements.js
+++ b/pageElements.js
@@ -1,3 +1,8 @@
+/*
+NOTE: This script is obsolete and contains elements that are NOT used in the current index.html or script.js.
+The existing index.html and script.js files were manually created and are more advanced.
+This script is kept for historical purposes only.
+*/
 const htmlStart = 
   `<!DOCTYPE html>
 <html>


### PR DESCRIPTION
This commit addresses several issues in the tftmixer repository:

1.  Corrected audio file extensions in `index.html`:
    - Changed all `.ogg` extensions in `<audio src="...">` tags to `.aac` to match the actual audio files in the `tracks/` directory and the files fetched by `script.js`.

2.  Fixed mismatched audio file paths in `index.html`:
    - Corrected the `src` for `audioheartsteel_late_drums` to point to `tracks/heartsteel_late_drums.aac`.
    - Corrected the `src` for `audioillbeats_late` to point to `tracks/illbeats_late.aac`.

3.  Removed redundant preset button in `index.html`:
    - Deleted a duplicate "u/Dr_Mr_G" preset button that incorrectly pointed to `preset8`.

4.  Marked obsolete generator scripts:
    - Added comments to `generatePage.js` and `pageElements.js` to clarify that they are obsolete and not used for the current site, preserving them for historical context.

These changes ensure that all audio tracks are correctly referenced, preset buttons are accurate, and the codebase is clearer by identifying unused scripts.